### PR TITLE
Add support for Tigrecar 3200

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,6 +23,7 @@
    · Salek ANS-1900 (bale trailer)
 
   SUPPORTED VEHCILES:
+   · Antonio Carraro Tigrecar 3200
    · Lizard Pickup 1986
    · Lizard Pickup 2017
    · Mahindra Retriever

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -143,6 +143,10 @@
 			<options rearUnloadingOnly="true"/>
             <loadingArea offset="0 0.900 -1.15" width="1.40" height="1.00" length="1.15"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="antonioCarraroPack/vehicles/antonioCarraro/tigrecar3200/tigrecar3200.xml" selectedConfigs="2">
+			<options isBaleTrailer="true"/>
+            <loadingArea offset="0 0.80 -0.85" width="1.30" height="1.20" length="2.10"/>
+        </vehicleConfiguration>	
 		
 		<!-- SUPPORTED MODS -->
         <!-- <vehicleConfiguration configFileName="FS22_lizardCarTrailer/lizardCarTrailer.xml"> -->


### PR DESCRIPTION
Add support for Tigrecar 3200 from Antonio Carraro DLC
It can fit 1 125cm round bale, 1 180cm rectangle bale, 12 125cm bales
And 2 pallets or 4 for the eggs

The loading area is 2cm wider than the back supports, but the 130cm width allows for the round bale.
It seems fine for me because when loading 2 pallets they are more at the front.
![tigrecar3200](https://user-images.githubusercontent.com/20406897/195995534-fba57f48-9b8d-45ac-bf9b-6fce2923141c.png)